### PR TITLE
FEATURE: add multilanguage capability

### DIFF
--- a/archives.php
+++ b/archives.php
@@ -109,11 +109,15 @@ class ArchivesPlugin extends Plugin
         // Get current datetime
         $start_date = time();
 
+        // Get current language
+        $language = $this->grav['language']->getLanguage();
+
         $archives = array();
 
         // get the plugin filters setting
         $filters = (array) $this->config->get('plugins.archives.filters');
         $operator = $this->config->get('plugins.archives.filter_combinator');
+        $multi_language = $this->config->get('plugins.archives.multilanguage');
         $new_approach = false;
         $collection = null;
 
@@ -139,6 +143,11 @@ class ArchivesPlugin extends Plugin
                     $find_taxonomy[$key] = $filter;
                 }
             }
+
+            if ($multi_language) {
+                $find_taxonomy[$key] = $language;
+            }
+
             if ($new_approach) {
                 $collection = $page->children();
             } else {

--- a/archives.php
+++ b/archives.php
@@ -145,7 +145,7 @@ class ArchivesPlugin extends Plugin
             }
 
             if ($multi_language) {
-                $find_taxonomy[$key] = $language;
+                $find_taxonomy['language'] = $language;
             }
 
             if ($new_approach) {


### PR DESCRIPTION
For my own purpose I added a new Configuration Flag in the archive plugin settings named `multilanguage`. If its true, the collection is filtered for a language taxonomy, and therefore the archive plugin displays the correct blogposts on a multilanguage site.