### PR TITLE
Fix collection retrieval

### DIFF
--- a/archives.php
+++ b/archives.php
@@ -224,9 +224,9 @@ class ArchivesPlugin extends Plugin
                 }
             }
             if ($new_approach) {
-                $collection = $page->children();
+                $collection = $page->collection('content', false);
             } elseif ($page_filter) {
-                $collection = $pages->find($page_filter)->children();
+                $collection = $pages->find($page_filter)->collection('content', false);
             } else {
                 $collection = new Collection();
                 $collection->append($taxonomy_map->findTaxonomy($find_taxonomy, $operator)->toArray());


### PR DESCRIPTION
`children()` only retrieves direct children, as per the code:
https://github.com/getgrav/grav/blob/1.6.27/system/src/Grav/Common/Page/Page.php#L2422

`collection()` is the proper retrieval method:
https://github.com/getgrav/grav/blob/1.6.27/system/src/Grav/Common/Page/Page.php#L2675

This can be confirmed by looking at what's used in default Quark theme when retrieving collection blog page template:
https://github.com/getgrav/grav-theme-quark/blob/2.0.3/templates/blog.html.twig#L3