### PR TITLE
Add taxonomy values date format customization

### DIFF
--- a/archives.php
+++ b/archives.php
@@ -17,6 +17,16 @@ class ArchivesPlugin extends Plugin
     /**
      * @var string
      */
+    protected $month_taxonomy_value;
+
+    /**
+     * @var string
+     */
+    protected $year_taxonomy_value;
+
+    /**
+     * @var string
+     */
     protected $month_taxonomy_name;
 
     /**
@@ -57,6 +67,9 @@ class ArchivesPlugin extends Plugin
             return;
         }
 
+        $this->month_taxonomy_value = $this->config->get('plugins.archives.taxonomy_values.month');
+        $this->year_taxonomy_value = $this->config->get('plugins.archives.taxonomy_values.year');
+
         $this->month_taxonomy_name = $this->config->get('plugins.archives.taxonomy_names.month');
         $this->year_taxonomy_name = $this->config->get('plugins.archives.taxonomy_names.year');
 
@@ -94,14 +107,14 @@ class ArchivesPlugin extends Plugin
 
         $taxonomy = $page->taxonomy();
 
-        // track month taxonomy in "jan_2015" format:
+        // track month taxonomy using month_taxonomy_value format:
         if (!isset($taxonomy[$this->month_taxonomy_name])) {
-            $taxonomy[$this->month_taxonomy_name] = array(strtolower(date('M_Y', $page->date())));
+            $taxonomy[$this->month_taxonomy_name] = array(strtolower(date($this->month_taxonomy_value, $page->date())));
         }
 
-        // track year taxonomy in "2015" format:
+        // track year taxonomy using year_taxonomy_value format:
         if (!isset($taxonomy[$this->year_taxonomy_name])) {
-            $taxonomy[$this->year_taxonomy_name] = array(date('Y', $page->date()));
+            $taxonomy[$this->year_taxonomy_name] = array(date($this->year_taxonomy_value, $page->date()));
         }
 
         // set the modified taxonomy back on the page object

--- a/archives.yaml
+++ b/archives.yaml
@@ -6,6 +6,9 @@ limit: 12
 taxonomy_names:
     month: archives_month
     year: archives_year
+taxonomy_values:
+    month: 'M_Y'
+    year: 'Y'
 #Defaults
 order:
     by: date

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -79,6 +79,12 @@ form:
         placeholder_key: e.g. month
         placeholder_value: e.g. archives_month
 
+    taxonomy_values:
+      type: array
+      label: Taxonomy Values (date format)
+      placeholder_key: e.g. month
+      placeholder_value: e.g. 'M_Y'
+
     defaults_section:
         type: section
         underline: true

--- a/templates/partials/archives.html.twig
+++ b/templates/partials/archives.html.twig
@@ -2,7 +2,7 @@
 
 {% for month,items in archives_data %}
     <li>
-    	<a href="{{ archives_url ?? base_url }}/{{ config.plugins.archives.taxonomy_names.month }}{{ config.system.param_sep }}{{ month|date('M_Y')|lower|e('url') }}">
+    	<a href="{{ archives_url ?? base_url }}/{{ config.plugins.archives.taxonomy_names.month }}{{ config.system.param_sep }}{{ month|date(config.plugins.archives.taxonomy_values.month)|lower|e('url') }}">
         {% if archives_show_count %}
         <span class="label">{{ items|length }}</span>
         {% endif %}


### PR DESCRIPTION
Allow users to customize taxonomy value dates form (and thus, indirectly, URLs), akin to taxonomy names customization.

Non-breaking change: defaults to previous behavior.